### PR TITLE
Add reservedCoreIds field to rmdworkload.

### DIFF
--- a/deploy/crds/intel.com_rmdworkloads_crd.yaml
+++ b/deploy/crds/intel.com_rmdworkloads_crd.yaml
@@ -90,6 +90,10 @@ spec:
                   type: object
               required:
               type: object
+            reservedCoreIds:
+              items:
+                type: string
+              type: array
           required:
           type: object
         status:

--- a/pkg/apis/intel/v1alpha1/rmdworkload_types.go
+++ b/pkg/apis/intel/v1alpha1/rmdworkload_types.go
@@ -53,13 +53,14 @@ type RmdWorkloadSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
-	AllCores     bool              `json:"allCores"`
-	CoreIds      []string          `json:"coreIds"`
-	Policy       string            `json:"policy,omniempty"`
-	Rdt          Rdt               `json:"rdt"`
-	Plugins      Plugins           `json:"plugins,omniempty"`
-	NodeSelector map[string]string `json:"nodeSelector"`
-	Nodes        []string          `json:"nodes"`
+	AllCores        bool              `json:"allCores"`
+	CoreIds         []string          `json:"coreIds"`
+	ReservedCoreIds []string          `json:"reservedCoreIds"`
+	Policy          string            `json:"policy,omniempty"`
+	Rdt             Rdt               `json:"rdt"`
+	Plugins         Plugins           `json:"plugins,omniempty"`
+	NodeSelector    map[string]string `json:"nodeSelector"`
+	Nodes           []string          `json:"nodes"`
 }
 
 // RmdWorkloadStatus defines the observed state of RmdWorkload

--- a/pkg/apis/intel/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/intel/v1alpha1/zz_generated.deepcopy.go
@@ -375,6 +375,11 @@ func (in *RmdWorkloadSpec) DeepCopyInto(out *RmdWorkloadSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ReservedCoreIds != nil {
+		in, out := &in.ReservedCoreIds, &out.ReservedCoreIds
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.Rdt = in.Rdt
 	out.Plugins = in.Plugins
 	if in.NodeSelector != nil {

--- a/pkg/nodeagent/pod_controller.go
+++ b/pkg/nodeagent/pod_controller.go
@@ -261,6 +261,7 @@ func buildRmdWorkload(pod *corev1.Pod) ([]*intelv1alpha1.RmdWorkload, error) {
 		rmdWorkload.Spec.Nodes = make([]string, 0)
 		rmdWorkload.Spec.Nodes = append(rmdWorkload.Spec.Nodes, pod.Spec.NodeName)
 		rmdWorkload.Spec.NodeSelector = make(map[string]string, 0)
+		rmdWorkload.Spec.ReservedCoreIds = make([]string, 0)
 
 		getAnnotationInfo(rmdWorkload, pod, container.Name) //Changes workload in getAnnotationInfo()
 

--- a/pkg/rmd/rmd.go
+++ b/pkg/rmd/rmd.go
@@ -268,6 +268,13 @@ func (rc *OperatorRmdClient) formatWorkload(workloadCR *intelv1alpha1.RmdWorkloa
 		if err != nil {
 			return &rmdtypes.RDTWorkLoad{}, err
 		}
+
+		if len(workloadCR.Spec.ReservedCoreIds) != 0 {
+			rsvdCPUSet := cpuset.MustParse(strings.Join(workloadCR.Spec.ReservedCoreIds, ","))
+			allCoresCPUSet := cpuset.MustParse(allCores)
+			finalCPUSet := allCoresCPUSet.Difference(rsvdCPUSet)
+			allCores = finalCPUSet.String()
+		}
 		coreIDs := []string{allCores}
 		rdtWorkload.CoreIDs = coreIDs
 	} else {

--- a/pkg/rmd/rmd_test.go
+++ b/pkg/rmd/rmd_test.go
@@ -153,6 +153,40 @@ func TestFormatWorkload(t *testing.T) {
 
 			expectedWorkload: expectedRDTWorkloads[6],
 		},
+		{
+			name:       "test case 7",
+			workloadCR: rmdWorkloads[7],
+			response: rmdCache.Infos{
+				Num: 0,
+				Caches: map[uint32]rmdCache.Info{
+					0: {
+						ShareCPUList: "0-23,48-71",
+					},
+					1: {
+						ShareCPUList: "24-47,72-95",
+					},
+				},
+			},
+
+			expectedWorkload: expectedRDTWorkloads[7],
+		},
+		{
+			name:       "test case ",
+			workloadCR: rmdWorkloads[8],
+			response: rmdCache.Infos{
+				Num: 0,
+				Caches: map[uint32]rmdCache.Info{
+					0: {
+						ShareCPUList: "0-23,48-71",
+					},
+					1: {
+						ShareCPUList: "24-47,72-95",
+					},
+				},
+			},
+
+			expectedWorkload: expectedRDTWorkloads[8],
+		},
 	}
 
 	for _, tc := range tcases {

--- a/pkg/rmd/test_cases.go
+++ b/pkg/rmd/test_cases.go
@@ -129,6 +129,50 @@ func rdtWorkLoadTestCases() []*rmdtypes.RDTWorkLoad {
 	wl7.Plugins = wl7plugins
 	wlds = append(wlds, wl7)
 
+	wl8 := &rmdtypes.RDTWorkLoad{}
+	wl8.CoreIDs = []string{"10-95"}
+	wl8.UUID = "rmd-workload-pod-8"
+	max8 := uint32(2)
+	wl8.Policy = "gold"
+	wl8.Rdt.Cache.Max = &max8
+	min8 := uint32(2)
+	wl8.Rdt.Cache.Min = &min8
+	mbaPercent8 := uint32(25)
+	wl8.Rdt.Mba.Percentage = &mbaPercent8
+	mbaMbps8 := uint32(150)
+	wl8.Rdt.Mba.Mbps = &mbaMbps8
+	wl8plugins := make(map[string]map[string]interface{})
+	ratio8 := float64(1.5)
+	wl8pstate := make(map[string]interface{})
+	wl8pstate["ratio"] = ratio8
+	wl8plugins["pstate"] = wl8pstate
+	monitoring8 := "on"
+	wl8plugins["pstate"]["monitoring"] = monitoring8
+	wl8.Plugins = wl8plugins
+	wlds = append(wlds, wl8)
+
+	wl9 := &rmdtypes.RDTWorkLoad{}
+	wl9.CoreIDs = []string{"0,3,8-95"}
+	wl9.UUID = "rmd-workload-pod-9"
+	max9 := uint32(2)
+	wl9.Policy = "gold"
+	wl9.Rdt.Cache.Max = &max9
+	min9 := uint32(2)
+	wl9.Rdt.Cache.Min = &min9
+	mbaPercent9 := uint32(25)
+	wl9.Rdt.Mba.Percentage = &mbaPercent9
+	mbaMbps9 := uint32(150)
+	wl9.Rdt.Mba.Mbps = &mbaMbps9
+	wl9plugins := make(map[string]map[string]interface{})
+	ratio9 := float64(1.5)
+	wl9pstate := make(map[string]interface{})
+	wl9pstate["ratio"] = ratio9
+	wl9plugins["pstate"] = wl9pstate
+	monitoring9 := "on"
+	wl9plugins["pstate"]["monitoring"] = monitoring9
+	wl9.Plugins = wl9plugins
+	wlds = append(wlds, wl9)
+
 	return wlds
 }
 
@@ -266,6 +310,60 @@ func rmdWorkloadTestCases() []*intelv1alpha1.RmdWorkload {
 			Spec: intelv1alpha1.RmdWorkloadSpec{
 				AllCores: true,
 				CoreIds:  []string{"1-2", "5", "11"},
+				Rdt: intelv1alpha1.Rdt{
+					Cache: intelv1alpha1.Cache{
+						Max: 2,
+						Min: 2,
+					},
+					Mba: intelv1alpha1.Mba{
+						Percentage: 25,
+						Mbps:       150,
+					},
+				},
+				Plugins: intelv1alpha1.Plugins{
+					Pstate: intelv1alpha1.Pstate{
+						Ratio:      "1.5",
+						Monitoring: "on",
+					},
+				},
+				Policy: "gold",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rmd-workload-pod-8",
+			},
+
+			Spec: intelv1alpha1.RmdWorkloadSpec{
+				AllCores:        true,
+				ReservedCoreIds: []string{"0-9"},
+				Rdt: intelv1alpha1.Rdt{
+					Cache: intelv1alpha1.Cache{
+						Max: 2,
+						Min: 2,
+					},
+					Mba: intelv1alpha1.Mba{
+						Percentage: 25,
+						Mbps:       150,
+					},
+				},
+				Plugins: intelv1alpha1.Plugins{
+					Pstate: intelv1alpha1.Pstate{
+						Ratio:      "1.5",
+						Monitoring: "on",
+					},
+				},
+				Policy: "gold",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rmd-workload-pod-9",
+			},
+
+			Spec: intelv1alpha1.RmdWorkloadSpec{
+				AllCores:        true,
+				ReservedCoreIds: []string{"1", "2", "4-7"},
 				Rdt: intelv1alpha1.Rdt{
 					Cache: intelv1alpha1.Cache{
 						Max: 2,

--- a/samples/rmdworkload-guaranteed-cache-allocatable.yaml
+++ b/samples/rmdworkload-guaranteed-cache-allocatable.yaml
@@ -1,0 +1,15 @@
+apiVersion: intel.com/v1alpha1
+kind: RmdWorkload
+metadata:
+  name: rmdworkload-guaranteed
+spec:
+  # Add fields here
+  allCores: true
+  reservedCoreIds: ["0-3"]
+  rdt:
+    cache:
+      max: 2
+      min: 2
+  nodeSelector:
+    # this is an example label as shown in README      
+    node.guaranteed.cache.only: "true"      


### PR DESCRIPTION
Option to RmdWorkload spec allows for alignment with kubelet configuration of `reserved-cpus` at node level